### PR TITLE
Adding prefix 2114 - Turing Network

### DIFF
--- a/ss58-registry.json
+++ b/ss58-registry.json
@@ -1017,6 +1017,15 @@
       "decimals": [12],
       "standardAccount": "*25519",
       "website": "https://nftmart.io"
+    },
+    {
+      "prefix": 2114,
+      "network": "turing",
+      "displayName": "Turing Network",
+      "symbols": ["TUR"],
+      "decimals": [10],
+      "standardAccount": "*25519",
+      "website": "https://oak.tech/turing/home/"
     }
   ]
 }


### PR DESCRIPTION
Adding Turing Network, the canary network of OAK (prefix 51).